### PR TITLE
Change base image to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,20 @@
-FROM continuumio/miniconda
+FROM alpine:3.6
 
 ARG UID=1000
 ARG GID=1000
 ARG MOUNTDIR=/tectonic
-ARG VERSION=0.1.5
 
-RUN conda config --add channels conda-forge && conda config --add channels pkgw-forge
-RUN conda install -y tectonic=${VERSION}
-
-RUN mkdir -p /home/tectonic/.cache && addgroup --gid ${GID} tectonic && useradd --home /home/tectonic --uid ${UID} --gid ${GID} tectonic && chown -R tectonic:tectonic /home/tectonic
+RUN mkdir -p /home/tectonic/.cache && addgroup -g ${GID} tectonic && adduser -D -h /home/tectonic -u ${UID} -G tectonic tectonic && chown -R tectonic:tectonic /home/tectonic
 RUN mkdir /tectonic && chown tectonic:tectonic /tectonic
 
+RUN apk add --no-cache rust cargo openssl openssl-dev make g++
+RUN apk add --no-cache fontconfig-dev harfbuzz-dev harfbuzz-icu icu-dev freetype-dev graphite2-dev libpng-dev zlib-dev
+
 USER tectonic
+
+RUN cargo install tectonic
+
+ENV PATH="/home/tectonic/.cargo/bin:${PATH}"
 
 VOLUME [ "${MOUNTDIR}" ]
 VOLUME [ "/home/tectonic/.cache" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ ARG VERSION=0.1.5
 RUN conda config --add channels conda-forge && conda config --add channels pkgw-forge
 RUN conda install -y tectonic=${VERSION}
 
-RUN addgroup --gid ${GID} tectonic && useradd --home /home/tectonic --uid ${UID} --gid ${GID} tectonic &&
-     chown -R tectonic:tectonic /home/tectonic
+RUN mkdir -p /home/tectonic/.cache && addgroup --gid ${GID} tectonic && useradd --home /home/tectonic --uid ${UID} --gid ${GID} tectonic && chown -R tectonic:tectonic /home/tectonic
 RUN mkdir /tectonic && chown tectonic:tectonic /tectonic
 
 USER tectonic

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:3.6
 ARG UID=1000
 ARG GID=1000
 ARG MOUNTDIR=/tectonic
+ARG VERSION=0.1.6
 
 RUN mkdir -p /home/tectonic/.cache && addgroup -g ${GID} tectonic && adduser -D -h /home/tectonic -u ${UID} -G tectonic tectonic && chown -R tectonic:tectonic /home/tectonic
 RUN mkdir /tectonic && chown tectonic:tectonic /tectonic
@@ -12,7 +13,7 @@ RUN apk add --no-cache fontconfig-dev harfbuzz-dev harfbuzz-icu icu-dev freetype
 
 USER tectonic
 
-RUN cargo install tectonic
+RUN cargo install --vers ${VERSION} tectonic
 
 ENV PATH="/home/tectonic/.cargo/bin:${PATH}"
 


### PR DESCRIPTION
👍  Makes the image smaller ~250MB
👍 Get rid of Anaconda
👍 Use cargo and rustc directly
👎 was not able to test it yet (invalid gzip header)