### PR TITLE
Drastically cut down image size through docker multi-stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ARG UID=1000
 ARG GID=1000
 ARG MOUNTDIR=/tectonic
 
-RUN apk add --no-cache fontconfig harfbuzz harfbuzz-icu icu freetype graphite2 libpng zlib openssl
+RUN apk add --no-cache fontconfig harfbuzz harfbuzz-icu icu freetype graphite2 libpng zlib openssl perl
 RUN mkdir -p /home/tectonic/.cache /home/tectonic/.cargo/bin /home/tectonic/.config/Tectonic /home/tectonic/bin /home/tectonic/man /tectonic && addgroup -g ${GID} tectonic && adduser -D -h /home/tectonic -u ${UID} -G tectonic tectonic && chown -R tectonic:tectonic /home/tectonic /tectonic
 
 USER tectonic

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ USER tectonic
 RUN cd /tmp && busybox wget http://mirror.switch.ch/ftp/mirror/tex/indexing/makeindex.zip && unzip makeindex.zip && rm makeindex.zip
 RUN cd /tmp/makeindex/src/ && make && cp makeindex /home/tectonic/bin/ && chmod 555 /home/tectonic/bin/makeindex && rm -rf /tmp/makeindex
 RUN cd /home/tectonic/bin && busybox wget http://mirrors.ctan.org/macros/latex/contrib/glossaries/makeglossaries && chmod +x makeglossaries
-RUN cargo install --vers 0.1.6 tectonic
+RUN cargo install --vers 0.1.8 tectonic
 
 FROM alpine:3.8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ARG UID=1000
 ARG GID=1000
 ARG MOUNTDIR=/tectonic
 
-RUN apk add --no-cache fontconfig-dev harfbuzz-dev harfbuzz-icu icu-dev freetype-dev graphite2-dev libpng-dev zlib-dev openssl
+RUN apk add --no-cache fontconfig harfbuzz harfbuzz-icu icu freetype graphite2 libpng zlib openssl
 RUN mkdir -p /home/tectonic/.cache /home/tectonic/.cargo/bin /home/tectonic/.config/Tectonic /home/tectonic/bin /home/tectonic/man /tectonic && addgroup -g ${GID} tectonic && adduser -D -h /home/tectonic -u ${UID} -G tectonic tectonic && chown -R tectonic:tectonic /home/tectonic /tectonic
 
 USER tectonic

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,32 @@
-FROM alpine:3.6
-
-ARG UID=1000
-ARG GID=1000
-ARG MOUNTDIR=/tectonic
-ARG VERSION=0.1.6
-
-RUN mkdir -p /home/tectonic/.cache /home/tectonic/.config/Tectonic /home/tectonic/bin /home/tectonic/man && addgroup -g ${GID} tectonic && adduser -D -h /home/tectonic -u ${UID} -G tectonic tectonic && chown -R tectonic:tectonic /home/tectonic
-RUN mkdir /tectonic && chown tectonic:tectonic /tectonic
+FROM alpine:3.8 as build
 
 RUN apk add --no-cache rust cargo openssl openssl-dev make g++
 RUN apk add --no-cache fontconfig-dev harfbuzz-dev harfbuzz-icu icu-dev freetype-dev graphite2-dev libpng-dev zlib-dev
+
+ARG UID=1000
+ARG GID=1000
+
+RUN mkdir -p /home/tectonic/.cache /home/tectonic/.config/Tectonic /home/tectonic/bin /home/tectonic/man && addgroup -g ${GID} tectonic && adduser -D -h /home/tectonic -u ${UID} -G tectonic tectonic && chown -R tectonic:tectonic /home/tectonic && mkdir /tectonic && chown tectonic:tectonic /tectonic
 
 USER tectonic
 RUN cd /tmp && busybox wget http://mirror.switch.ch/ftp/mirror/tex/indexing/makeindex.zip && unzip makeindex.zip && rm makeindex.zip
 RUN cd /tmp/makeindex/src/ && make && cp makeindex /home/tectonic/bin/ && chmod 555 /home/tectonic/bin/makeindex && rm -rf /tmp/makeindex
 RUN cd /home/tectonic/bin && busybox wget http://mirrors.ctan.org/macros/latex/contrib/glossaries/makeglossaries && chmod +x makeglossaries
-RUN cargo install --vers ${VERSION} tectonic
+RUN cargo install --vers 0.1.6 tectonic
+
+FROM alpine:3.8
+
+ARG UID=1000
+ARG GID=1000
+ARG MOUNTDIR=/tectonic
+
+RUN apk add --no-cache fontconfig-dev harfbuzz-dev harfbuzz-icu icu-dev freetype-dev graphite2-dev libpng-dev zlib-dev openssl
+RUN mkdir -p /home/tectonic/.cache /home/tectonic/.cargo/bin /home/tectonic/.config/Tectonic /home/tectonic/bin /home/tectonic/man /tectonic && addgroup -g ${GID} tectonic && adduser -D -h /home/tectonic -u ${UID} -G tectonic tectonic && chown -R tectonic:tectonic /home/tectonic /tectonic
+
+USER tectonic
+
+COPY --from=build /home/tectonic/.cargo/bin /home/tectonic/.cargo/bin
+COPY --from=build /home/tectonic/bin /home/tectonic/bin
 
 ADD config.toml /home/tectonic/.config/Tectonic/
 ENV PATH="/home/tectonic/.cargo/bin:/home/tectonic/bin/:${PATH}"


### PR DESCRIPTION
This PR brings several changes/improvements:

- Significantly lower image size

With docker multi-stage builds, we can separate the building process from the runtime:
1. All the install dependencies like Rust, C++ are no longer contained in the final image.
2. We can install only the runtime versions of the needed packages like `openssl` instead of `openssl-dev`.

Before: 584MB ![image](https://user-images.githubusercontent.com/5486389/42694106-8e41539a-86f4-11e8-9999-2fc13d1f4907.png)

After: 56.5MB ![image](https://user-images.githubusercontent.com/5486389/42694090-8556ca4e-86f4-11e8-9fcc-782682d111de.png)

And this is even uncompressed :)
On docker-hub, the original one has only 240MB!

- Update alpine to 3.8

Even the current image does not longer compile due to changes on the rust source code. alpine:3.6 comes with Rust 1.17 which can no longer compile tectonic.

- Update tectonic to version 0.1.8
